### PR TITLE
Update validator launch path

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ python3 app/validators/cadastro_validador.py
 
 #### 🛡️ Para subir os validadores (portas 5002 a 5011)
 ```bash
-python3 app/validators/subir_validadores.py 
+python3 app/validators/subir_validadores.py
 ```
+O caminho para `run_validador.py` é resolvido dinamicamente dentro desse script,
+dispensando a necessidade de usar caminhos absolutos.
 
 #### 🛡️ Para matar todos os validadores (portas 5002 a 5011)
 ```bash

--- a/app/validators/subir_validadores.py
+++ b/app/validators/subir_validadores.py
@@ -19,8 +19,11 @@ def subir_validadores():
         id_validador = validador['id']
         eh_malicioso = "1" if id_validador == 10 else "0"
 
+        script_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'run_validador.py'
+        )
         subprocess.Popen([
-            "python3", "/home/ubuntu/Programacao-Distribuida/run_validador.py"
+            "python3", script_path
         ], env={
             "PORTA": str(porta),
             "VALIDADOR_ID": str(id_validador),


### PR DESCRIPTION
## Summary
- use `os.path.join` in `subir_validadores.py` to locate `run_validador.py`
- document dynamic path resolution

## Testing
- `python3 -m py_compile app/validators/subir_validadores.py`
- `python3 -m py_compile run_validador.py`


------
https://chatgpt.com/codex/tasks/task_b_683db41354ac832b8198f563a5a162c0