### PR TITLE
Update HOST_API default

### DIFF
--- a/app/utils/time_utils.py
+++ b/app/utils/time_utils.py
@@ -1,7 +1,7 @@
 import requests
 import os
 
-HOST_API = os.getenv("HOST_API", "http://127.0.0.1")
+HOST_API = os.getenv("HOST_API", "127.0.0.1")
 
 def hora_sistema():
     url = f'http://{HOST_API}:5000/hora'


### PR DESCRIPTION
## Summary
- change default `HOST_API` to be the bare IP

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_683dd49db24c832bab584b66b053894c