### PR TITLE
Add /hora endpoint and documentation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,7 @@ def create_app():
     from app.controllers.TransacaoController import transacao_bp
     from app.controllers.ValidadorController import validador_bp
     from app.controllers.SeletorLocalController import seletorlocal_bp
+    from app.controllers.HoraController import hora_bp
 
 
     app.register_blueprint(cliente_bp)
@@ -25,6 +26,7 @@ def create_app():
     app.register_blueprint(transacao_bp)
     app.register_blueprint(validador_bp)
     app.register_blueprint(seletorlocal_bp)
+    app.register_blueprint(hora_bp)
 
 
     return app

--- a/app/controllers/HoraController.py
+++ b/app/controllers/HoraController.py
@@ -1,0 +1,9 @@
+from flask import Blueprint, jsonify
+from datetime import datetime
+
+hora_bp = Blueprint('hora_bp', __name__)
+
+@hora_bp.route('/hora', methods=['GET'])
+def obter_hora():
+    now = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
+    return jsonify({'hora': now})

--- a/app/templates/api.html
+++ b/app/templates/api.html
@@ -54,15 +54,18 @@
                   
 
                 <h3>Hora</h3>
-                <div class="accordion accordion-flush" id="accordionFlushExample">
+                <div class="accordion accordion-flush" id="accordionHora">
                     <div class="accordion-item">
-                      <h2 class="accordion-header" id="flush-headingOne">
-                        <button class="accordion-button collapsed" style="padding: 5px" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseOne" aria-expanded="false" aria-controls="flush-collapseOne">
+                      <h2 class="accordion-header" id="hora-heading">
+                        <button class="accordion-button collapsed" style="padding: 5px" type="button" data-bs-toggle="collapse" data-bs-target="#hora-collapse" aria-expanded="false" aria-controls="hora-collapse">
                             <h5 style="margin-bottom: 1px;margin-right: 10px"><span class="badge bg-secondary">GET</span></h5> <kbd>/hora</kbd>
                         </button>
                       </h2>
-                  </div>
-            </div>
+                      <div id="hora-collapse" class="accordion-collapse collapse" aria-labelledby="hora-heading" data-bs-parent="#accordionHora">
+                        <div class="accordion-body">Retorna o timestamp atual do servidor.</div>
+                      </div>
+                    </div>
+                </div>
 
             <h3>Transações</h3>
                 <div class="accordion accordion-flush" id="accordionFlushExample">

--- a/tests/test_hora.py
+++ b/tests/test_hora.py
@@ -1,0 +1,28 @@
+import sys
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+from app.utils.time_utils import hora_sistema
+
+
+def test_hora_endpoint():
+    app = create_app()
+    with app.test_client() as client:
+        response = client.get('/hora')
+        assert response.status_code == 200
+        data = response.get_json()
+        assert 'hora' in data
+
+
+def test_hora_sistema():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {'hora': '2025-01-01 12:00:00.000000'}
+    with patch('requests.get', return_value=mock_resp) as mock_get:
+        data = hora_sistema()
+        assert data == {'hora': '2025-01-01 12:00:00.000000'}
+        mock_get.assert_called()


### PR DESCRIPTION
## Summary
- implement `HoraController` with `/hora` route
- register blueprint in app factory
- document the new endpoint in `api.html`
- provide tests for endpoint and `hora_sistema`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_683dd511da54832bb14eb29f2095a1ab