### PR TITLE
Update validator deletion logic

### DIFF
--- a/app/controllers/ValidadorController.py
+++ b/app/controllers/ValidadorController.py
@@ -41,5 +41,7 @@ def apagar_validador(id):
     db.session.delete(objeto)
     db.session.commit()
 
+    calcular_percent()
+
     return jsonify({"message": "Validador Deletado com Sucesso"})
 


### PR DESCRIPTION
## Summary
- update ValidadorController.apagar_validador to recalculate validator percentages after deletion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_683dd76e75a4832bb3baa46dc8967948