### PR TITLE
Handle empty validator pool

### DIFF
--- a/app/controllers/SeletorLocalController.py
+++ b/app/controllers/SeletorLocalController.py
@@ -50,6 +50,9 @@ def receber_transacao(id, remetente, idSeletor, valor, horario):
     rem = visualizar_Cliente_id(remetente)
     escolhidos = escolhe_validadores()
 
+    if not escolhidos:
+        return jsonify({"error": "Sem validadores disponíveis"})
+
     saldoRem = rem['qtdMoeda']
     resultado_json = []
 

--- a/app/services/validador_service.py
+++ b/app/services/validador_service.py
@@ -44,7 +44,7 @@ def escolhe_validadores():
         Validadores = Validador.query.all()
         if len(Validadores) < 3:
             logger.error('Não foi possivel concluir a transação por falta de validadores')
-            return 0
+            return []
     if len(Validadores) >= 5:
         escolhidos = cinco_validadores()
         logger.info('5 ou mais validadores os escolhidos sao:  %s', escolhidos)


### PR DESCRIPTION
## Summary
- return empty list when validators are insufficient
- fail fast in SeletorLocalController when no validators are available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_683dd6572780832bb6aa1af3b4b0ddde